### PR TITLE
added windows commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please join us at the slack group [INSERT LINK]
 - python 3.7 or higher 
 - install [Docker](https://docs.docker.com/docker-for-mac/install/)  
 
-## Homebrew installations:
+## Mac Homebrew installations:
 
 ```bash
 brew install docker-compose
@@ -31,8 +31,14 @@ then start it with `docker-compose up`
 
 Then get a shell in the docker container and create a superuser
 
+### mac
 ```bash
 $ docker exec -ti pandaid-api_web_1 /bin/bash
+:/code# python manage.py createsuperuser --email admin@example.com --username admin
+```
+### windows
+```bash
+$ winpty docker exec -it pandaid-api_web_1 //bin/sh
 :/code# python manage.py createsuperuser --email admin@example.com --username admin
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,33 +10,51 @@ Please join us at the slack group [INSERT LINK]
 # Prerequisites
 
 - python 3.7 or higher 
-- install [Docker](https://docs.docker.com/docker-for-mac/install/)  
+- install [Docker](https://docs.docker.com/)  
 
-## Mac Homebrew installations:
-
-```bash
-brew install docker-compose
-```
 
 # Local Development
+All commands in bash regardless of operating system unless otherwise noted
 
-## setup
 
+## mac
+
+### Homebrew installations:
+
+```bash
+$ brew install docker-compose
+```
+### setup
 The first time you work on this, build the docker image:
 ```bash
 docker-compose build
 ```
 
-then start it with `docker-compose up`
+Then start it with 
+```bash
+docker-compose up
+```
 
 Then get a shell in the docker container and create a superuser
 
-### mac
-```bash
+```
 $ docker exec -ti pandaid-api_web_1 /bin/bash
 :/code# python manage.py createsuperuser --email admin@example.com --username admin
 ```
-### windows
+## windows
+### setup
+The first time you work on this, build the docker image:
+```bash
+docker-compose build
+```
+
+Then start it with 
+```bash
+docker-compose up
+```
+
+Then get a shell in the docker container and create a superuser
+
 ```bash
 $ winpty docker exec -it pandaid-api_web_1 //bin/sh
 :/code# python manage.py createsuperuser --email admin@example.com --username admin


### PR DESCRIPTION
I didn't add the docker installation instructions for Windows because I think there are too many variables depending on the version of Windows you have. I have Windows 10 Home which does not support Docker Desktop, so I had to follow the instructions for Docker Toolbox. The Docker Desktop installation wizard will tell you if this is what you need to do. 

However, once I was passed that hurdle, it did take me a minute to figure out how to run a shell in the container. The error wasn't very verbose. I eventually discovered that simply the same commands didn't work for windows, so I added the variation that I was able to use. 