### PR TITLE
Fix Issue #13: Add CORS Support

### DIFF
--- a/pandaid-rest-api/config/common.py
+++ b/pandaid-rest-api/config/common.py
@@ -21,6 +21,7 @@ class Common(Configuration):
         'rest_framework',            # utilities for rest apis
         'rest_framework.authtoken',  # token authentication
         'django_filters',            # for filtering rest endpoints
+        'corsheaders',               # for CORS support with client
 
         # Your apps
         'pandaid-rest-api.users',
@@ -32,14 +33,15 @@ class Common(Configuration):
     MIDDLEWARE = (
         'django.middleware.security.SecurityMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
+        'corsheaders.middleware.CorsMiddleware',
         'django.middleware.common.CommonMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
     )
-
     ALLOWED_HOSTS = ["*"]
+    CORS_ORGIN_ALLOW_ALL = True
     ROOT_URLCONF = 'pandaid-rest-api.urls'
     SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
     WSGI_APPLICATION = 'pandaid-rest-api.wsgi.application'

--- a/pandaid-rest-api/users/test/test_headers.py
+++ b/pandaid-rest-api/users/test/test_headers.py
@@ -1,0 +1,28 @@
+from django.urls import reverse
+from nose.tools import ok_, eq_
+from rest_framework.test import APITestCase
+import factory
+from .factories import UserFactory
+
+
+class TestMyTestsTestCase(APITestCase):
+
+    def test_if_this_fails(self):
+        test="success"
+        ok_(test, "fail")
+
+
+class TestCORSHeadersTestCase(APITestCase):
+    """
+    Tests the Django CORS Headers package is working properly 
+    and Access-Control-Allow-Origin exists in response headers.
+    """
+
+    def setUp(self):
+        self.url = reverse('api-token-auth/')
+        self.user_data = factory.build(dict, FACTORY_CLASS=UserFactory)
+
+    def test_post_request_has_correct_headers(self):
+        response = self.client.post(self.url, self.user_data)
+        ok_(response.headers["access-control-allow-origin"], "*")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ django_unique_upload==0.2.1
 djangorestframework==3.11.0
 Markdown==3.1.1
 django-filter==2.2.0
+django-cors-headers==3.2.1
 
 # Developer Tools
 ipdb==0.12.3


### PR DESCRIPTION
---
name: Adding CORS Support to the API
about: Implementing django-cors-headers package and testing it.
---


## What does this do and why?

As mentioned in Issue https://github.com/Pand-Aid/pandaid-api/issues/13, our API needs to set the correct headers to be accessible to the front end. 

I added the `django-cors-headers` package to requirements.txt and followed the setup detailed at https://github.com/adamchainz/django-cors-headers/blob/master/README.rst



## Additional notes for reviewers

The response headers should be set to `ACCESS-CONTROL-ALLOW-ORIGIN: "*"`
I attempted to write a test to prove this. I've never written a test for this before, as I usually trouble-shoot CORS in the browser terminal or Postman. I sent up a test designed to replicate that by sending a `POST` request to 'api-token-auth/" as is mentioned in the main README setup.
https://github.com/Pand-Aid/pandaid-api/blob/master/README.md

I followed the format of the previously written tests within the User module. It implemented `UserFactory` for temporary test users as well as `Nosetests`. I did my best putting a test together using these libraries. 

_**However, I cannot get the tests to run to see if they are being used correctly.**_ 

I also wrote a very simple test that is designed to fail, so I could easily see when tests were running. 

### Commands Used and Terminal Feedback:

```
~pandaid-api/pandaid-rest-api/users/        
$ winpty docker exec -it pandaid-api_web_1 //bin/sh
# python manage.py test 
```

The test command returns this in the bash terminal:
```
OK!  0 tests, 0 failures, 0 errors in 0.0s
```

and triggers this is the Docker terminal:
```
FATAL: database "test_postgres" does not exist
```

## Pre-Review Tasks

Place an ‘x’ between the brackets.

[ x] I wrote tests covering these changes

[ ] I reviewed my own PR before asking for review from others

[ ] I added PR comments providing additional context for reviewers where appropriate, or calling attention to especially sensitive changes.

[ ] If deps were added, I verified the licenses

